### PR TITLE
Move project metadata to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,35 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools >= 36.6"]
+requires = ["setuptools >= 61.0"]
+
+[project]
+name = "colored"
+version = "0.4.0"
+description = "Automatically color uncaught exception tracebacks"
+authors = [
+    { name = "Anton Backer", email = "olegov@gmail.com" },
+]
+readme = "README.rst"
+license = { text = "ISC" }
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Natural Language :: English",
+    "License :: OSI Approved :: ISC License (ISCL)",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS :: MacOS X",
+    "Operating System :: Microsoft :: Windows",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3.7",
+]
+
+[project.urls]
+Source = "https://www.github.com/staticshock/colored-traceback.py"
+
+[tool.setuptools]
+packages = [
+    "colored_traceback",
+    "colored_traceback.auto",
+    "colored_traceback.always",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ build-backend = "setuptools.build_meta"
 requires = ["setuptools >= 61.0"]
 
 [project]
-name = "colored"
+name = "colored-traceback"
 version = "0.4.0"
 description = "Automatically color uncaught exception tracebacks"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,8 @@ classifiers = [
     "Operating System :: MacOS :: MacOS X",
     "Operating System :: Microsoft :: Windows",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 2.7",
+    "Programming Language :: Python :: 3.3",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,10 @@ classifiers = [
     "Programming Language :: Python :: 3.3",
 ]
 
+dependencies = [
+    "pygments",
+]
+
 [project.urls]
 Source = "https://www.github.com/staticshock/colored-traceback.py"
 

--- a/setup.py
+++ b/setup.py
@@ -1,36 +1,3 @@
-try:
-    from setuptools import setup
-    has_setuptools = True
-except:
-    from distutils.core import setup
-    has_setuptools = False
+from setuptools import setup
 
-extra_args = {}
-if has_setuptools:
-    extra_args['install_requires'] = ['pygments']
-
-setup(
-    name='colored-traceback',
-    version='0.4.0',
-    description='Automatically color uncaught exception tracebacks',
-    long_description=open("README.rst").read(),
-    author='Anton Backer',
-    author_email='olegov@gmail.com',
-    url='http://www.github.com/staticshock/colored-traceback.py',
-    packages=['colored_traceback', 'colored_traceback.auto', 'colored_traceback.always'],
-    license='ISC',
-    classifiers=(
-        'Development Status :: 4 - Beta',
-        'Environment :: Console',
-        'Intended Audience :: Developers',
-        'Natural Language :: English',
-        'License :: OSI Approved :: ISC License (ISCL)',
-        'Operating System :: POSIX :: Linux',
-        'Operating System :: MacOS :: MacOS X',
-        'Operating System :: Microsoft :: Windows',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
-    ),
-    **extra_args
-)
+setup()


### PR DESCRIPTION
See [Python packaging docs](https://packaging.python.org/en/latest/guides/writing-pyproject-toml) and [setuptools docs](https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html).

Depends on staticshock/colored-traceback.py#21